### PR TITLE
fix: reduce duplicate API calls on login and dashboard load

### DIFF
--- a/src/context/auth/AuthProvider.jsx
+++ b/src/context/auth/AuthProvider.jsx
@@ -48,11 +48,10 @@ export const AuthProvider = ({ children }) => {
       localStorage.setItem("user", JSON.stringify(student));
       setUser(student);
       
-      // Crear profileData con los datos del login
       const profileData = {
         student: student,
-        reviews: [], // Se cargarán cuando sea necesario
-        tries: []    // Se cargarán cuando sea necesario
+        reviews: { rows: [] },
+        tries: { rows: [] },
       };
       
       localStorage.setItem("profileData", JSON.stringify(profileData));
@@ -63,6 +62,12 @@ export const AuthProvider = ({ children }) => {
         setCareerHeader(student.matriculaciones[0].carrera.id);
         localStorage.setItem("careerId", student.matriculaciones[0].carrera.id);
       }
+
+      // Cargar reseñas e intentos en background — el login no los devuelve
+      fetchProfile(jwt).then(full => {
+        setProfileData(full);
+        localStorage.setItem("profileData", JSON.stringify(full));
+      }).catch(() => {});
 
       return student;
     } finally {

--- a/src/layouts/PrivateLayout.jsx
+++ b/src/layouts/PrivateLayout.jsx
@@ -19,13 +19,7 @@ export default function PrivateLayout() {
     }
   }, [user, isGuest, profileData, getProfile]);
 
-  // Refrescar perfil al abrir el menú
-  useEffect(() => {
-    if (isOpen && !isGuest && user) {
-      getProfile();
-    }
-  }, [isOpen]);
-
+  
   // Cierre con click outside
   useEffect(() => {
     function handleClickOutside(event) {

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -186,14 +186,14 @@ export default function Dashboard() {
   }, [teacherFilters, isChangingCareer, searchMode]);
 
   useEffect(() => {
-    if (user && selectedCareer && !isChangingCareer) {
+    if (selectedCareer && !isChangingCareer) {
       if (searchMode === 'subjects') {
         fetchSubjects({ ...searchParams, limit, page: currentPage });
       } else {
         fetchTeachers({ search: searchParams.search, limit, page: currentPage });
       }
     }
-  }, [searchParams, currentPage, selectedCareer, isChangingCareer, user, searchMode]);
+  }, [searchParams, currentPage, selectedCareer, isChangingCareer, searchMode]);
 
   const fetchTeachers = async (params) => {
     const data = await fetchTeachersApi(params);


### PR DESCRIPTION
 Se identificaron 3 causas de requests duplicados al backend:

  - PrivateLayout llamaba getProfile() en cada apertura del menú de usuario,
    generando un GET /auth/profile por cada click en el avatar.

  - El endpoint de login no devuelve reviews ni tries, por lo que
    profileData.reviews era undefined tras el login. PrivateLayout
    interpretaba eso como "perfil no cargado" y disparaba un segundo
    GET /auth/profile innecesario. Se inicializa profileData con
    reviews: { rows: [] } y tries: { rows: [] } para evitarlo.
    Se agrega fetchProfile() en background al terminar el login para
    cargar las reseñas reales sin bloquear la navegación.

  - Dashboard incluía user en las dependencias del useEffect de fetch junto
    a selectedCareer, que ya se deriva de user, provocando doble llamada a
    /materias o /docentes en cada carga.